### PR TITLE
Add async extensions, tests & API modernizations

### DIFF
--- a/src/S7PlcRx.TestApp/S7PlcRx.TestApp.csproj
+++ b/src/S7PlcRx.TestApp/S7PlcRx.TestApp.csproj
@@ -8,7 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\MockS7Plc\MockS7Plc.csproj" />
     <ProjectReference Include="..\S7PlcRx\S7PlcRx.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\MockS7Plc\runtimes\win-x64\native\snap7.dll" Link="runtimes\win-x64\native\snap7.dll" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\MockS7Plc\runtimes\win-x86\native\snap7.dll" Link="runtimes\win-x86\native\snap7.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/S7PlcRx.Tests/S7PlcRxAsyncExtensionsTests.cs
+++ b/src/S7PlcRx.Tests/S7PlcRxAsyncExtensionsTests.cs
@@ -1,0 +1,519 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers.Binary;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MockS7Plc;
+using ReactiveUI.Extensions.Async;
+using S7PlcRx.Advanced;
+using S7PlcRx.Enums;
+
+namespace S7PlcRx.Tests;
+
+/// <summary>
+/// Tests the async extension surface added on top of <see cref="IRxS7"/>.
+/// </summary>
+public class S7PlcRxAsyncExtensionsTests
+{
+    /// <summary>
+    /// Verifies cached reads complete synchronously.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ReadValueAsync_WhenCachedValueExists_CompletesSynchronously()
+    {
+        var plc = new TestPlc();
+        plc.TagList.Add(new Tag("Cached", "DB1.DBW0", typeof(ushort)) { Value = (ushort)42 });
+
+        var valueTask = plc.ReadValueAsync<ushort>("Cached");
+
+        Assert.That(valueTask.IsCompleted, Is.True);
+        Assert.That(await valueTask.AsTask(), Is.EqualTo((ushort)42));
+        Assert.That(plc.SyncReadCount, Is.EqualTo(0));
+    }
+
+    /// <summary>
+    /// Verifies canceled reads surface an operation canceled exception.
+    /// </summary>
+    [Test]
+    public void ReadValueAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        var plc = new TestPlc();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.That(
+            async () => await plc.ReadValueAsync<ushort>("Canceled", cts.Token).AsTask(),
+            Throws.InstanceOf<OperationCanceledException>());
+    }
+
+    /// <summary>
+    /// Verifies uncached reads use the underlying task-based read path.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ReadValueAsync_WhenCacheMissing_UsesTaskReadPath()
+    {
+        var plc = new TestPlc();
+        plc.SetSyncValue("Live", (ushort)7);
+
+        var value = await plc.ReadValueAsync<ushort>("Live").AsTask();
+
+        Assert.That(value, Is.EqualTo((ushort)7));
+        Assert.That(plc.SyncReadCount, Is.EqualTo(1));
+    }
+
+    /// <summary>
+    /// Verifies empty batch reads return an empty dictionary.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ReadValuesAsync_WhenVariablesEmpty_ReturnsEmptyDictionary()
+    {
+        var plc = new TestPlc();
+
+        var values = await plc.ReadValuesAsync<ushort>(Array.Empty<string>()).AsTask();
+
+        Assert.That(values, Is.Empty);
+    }
+
+    /// <summary>
+    /// Verifies cached batch reads complete synchronously.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ReadValuesAsync_WhenCachedValuesExist_CompletesSynchronously()
+    {
+        var plc = new TestPlc();
+        plc.TagList.Add(new Tag("A", "DB1.DBW0", typeof(ushort)) { Value = (ushort)1 });
+        plc.TagList.Add(new Tag("B", "DB1.DBW2", typeof(ushort)) { Value = (ushort)2 });
+
+        var valueTask = plc.ReadValuesAsync<ushort>("A", "B");
+        var values = await valueTask.AsTask();
+
+        Assert.That(valueTask.IsCompleted, Is.True);
+        Assert.That(values["A"], Is.EqualTo((ushort)1));
+        Assert.That(values["B"], Is.EqualTo((ushort)2));
+        Assert.That(plc.SyncReadCount, Is.EqualTo(0));
+    }
+
+    /// <summary>
+    /// Verifies cancellable batch reads use the async read path.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ReadValuesAsync_WhenCancellationTokenCanBeUsed_UsesAsyncReadPath()
+    {
+        var plc = new TestPlc();
+        plc.SetAsyncValue("A", (ushort)11);
+        plc.SetAsyncValue("B", (ushort)22);
+        using var cts = new CancellationTokenSource();
+
+        var values = await plc.ReadValuesAsync<ushort>(new[] { "A", "B" }, cts.Token).AsTask();
+
+        Assert.That(values["A"], Is.EqualTo((ushort)11));
+        Assert.That(values["B"], Is.EqualTo((ushort)22));
+        Assert.That(plc.AsyncReadCount, Is.EqualTo(2));
+    }
+
+    /// <summary>
+    /// Verifies deferred async batch reads are awaited to completion.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ReadValuesAsync_WhenAsyncReadsAreDeferred_AwaitsCompletion()
+    {
+        var plc = new TestPlc();
+        var completion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        plc.SetAsyncFactory(
+            "A",
+            async cancellationToken =>
+            {
+                var completedTask = await Task.WhenAny(completion.Task, Task.Delay(Timeout.Infinite, cancellationToken));
+                if (completedTask != completion.Task)
+                {
+                    throw new OperationCanceledException(cancellationToken);
+                }
+
+                return await completion.Task;
+            });
+
+        using var cts = new CancellationTokenSource();
+        var valueTask = plc.ReadValuesAsync<ushort>(new[] { "A" }, cts.Token);
+
+        Assert.That(valueTask.IsCompleted, Is.False);
+
+        completion.SetResult((ushort)5);
+        var values = await valueTask.AsTask();
+
+        Assert.That(values["A"], Is.EqualTo((ushort)5));
+    }
+
+    /// <summary>
+    /// Verifies the optimized RxS7 multi-variable read path is used when available.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ReadValuesAsync_WhenRxMultiVarCanBeUsed_ReturnsExpectedValues()
+    {
+        using var server = new MockServer();
+        server.DefaultDb1Size = 16;
+        Assert.That(server.Start(), Is.EqualTo(0));
+
+        BinaryPrimitives.WriteUInt16BigEndian(server.DefaultDb1!.AsSpan(0, 2), 100);
+        BinaryPrimitives.WriteUInt16BigEndian(server.DefaultDb1.AsSpan(2, 2), 200);
+
+        using var plc = new RxS7(CpuType.S71500, MockServer.Localhost, 0, 1, null, interval: 100);
+        plc.AddUpdateTagItem<ushort>("A", "DB1.DBW0").SetTagPollIng(false);
+        plc.AddUpdateTagItem<ushort>("B", "DB1.DBW2").SetTagPollIng(false);
+
+        await plc.IsConnected.FirstAsync(x => x).Timeout(TimeSpan.FromSeconds(10));
+        var values = await plc.ReadValuesAsync<ushort>("A", "B").AsTask();
+
+        Assert.That(values["A"], Is.EqualTo((ushort)100));
+        Assert.That(values["B"], Is.EqualTo((ushort)200));
+    }
+
+    /// <summary>
+    /// Verifies cached values are bypassed when the runtime value type no longer matches the tag type.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ReadValueAsync_WhenCachedRuntimeTypeMismatches_FallsBackToRead()
+    {
+        var plc = new TestPlc();
+        plc.TagList.Add(new Tag("A", "DB1.DBW0", typeof(ushort)) { Value = 99 });
+        plc.SetSyncValue("A", (ushort)77);
+
+        var value = await plc.ReadValueAsync<ushort>("A").AsTask();
+
+        Assert.That(value, Is.EqualTo((ushort)77));
+        Assert.That(plc.SyncReadCount, Is.EqualTo(1));
+    }
+
+    /// <summary>
+    /// Verifies blank variable names are rejected.
+    /// </summary>
+    [Test]
+    public void ReadValuesAsync_WhenVariableNameIsBlank_ThrowsArgumentNullException()
+    {
+        var plc = new TestPlc();
+
+        Assert.ThrowsAsync<ArgumentNullException>(async () => await plc.ReadValuesAsync<ushort>(new[] { string.Empty }, CancellationToken.None).AsTask());
+    }
+
+    /// <summary>
+    /// Verifies fallback batch writes update each requested tag.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task WriteValuesAsync_WhenCalled_WritesExpectedValues()
+    {
+        var plc = new TestPlc();
+        var values = new Dictionary<string, ushort>
+        {
+            ["A"] = 10,
+            ["B"] = 20,
+        };
+
+        var valueTask = plc.WriteValuesAsync(values);
+        await valueTask.AsTask();
+
+        Assert.That(valueTask.IsCompleted, Is.True);
+        Assert.That(plc.WrittenValues["A"], Is.EqualTo((ushort)10));
+        Assert.That(plc.WrittenValues["B"], Is.EqualTo((ushort)20));
+    }
+
+    /// <summary>
+    /// Verifies canceled writes stop before dispatch.
+    /// </summary>
+    [Test]
+    public void WriteValuesAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        var plc = new TestPlc();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await plc.WriteValuesAsync(new Dictionary<string, ushort> { ["A"] = 10 }, cts.Token).AsTask());
+    }
+
+    /// <summary>
+    /// Verifies the optimized RxS7 multi-variable write path updates DB values.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task WriteValuesAsync_WhenRxMultiVarCanBeUsed_WritesExpectedValues()
+    {
+        using var server = new MockServer();
+        server.DefaultDb1Size = 16;
+        Assert.That(server.Start(), Is.EqualTo(0));
+
+        using var plc = new RxS7(CpuType.S71500, MockServer.Localhost, 0, 1, null, interval: 100);
+        plc.AddUpdateTagItem<ushort>("A", "DB1.DBW0").SetTagPollIng(false);
+        plc.AddUpdateTagItem<ushort>("B", "DB1.DBW2").SetTagPollIng(false);
+
+        await plc.IsConnected.FirstAsync(x => x).Timeout(TimeSpan.FromSeconds(10));
+        await plc.WriteValuesAsync(new Dictionary<string, ushort> { ["A"] = 321, ["B"] = 654 }).AsTask();
+        await Task.Delay(100);
+
+        Assert.That(BinaryPrimitives.ReadUInt16BigEndian(server.DefaultDb1!.AsSpan(0, 2)), Is.EqualTo((ushort)321));
+        Assert.That(BinaryPrimitives.ReadUInt16BigEndian(server.DefaultDb1.AsSpan(2, 2)), Is.EqualTo((ushort)654));
+    }
+
+    /// <summary>
+    /// Verifies the existing batch read helper routes through the new async read extensions.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ValueBatch_WhenCalled_UsesAsyncReadExtensions()
+    {
+        var plc = new TestPlc();
+        plc.TagList.Add(new Tag("A", "DB1.DBW0", typeof(ushort)) { Value = (ushort)9 });
+
+        var values = await plc.ValueBatch<ushort>("A");
+
+        Assert.That(values["A"], Is.EqualTo((ushort)9));
+    }
+
+    /// <summary>
+    /// Verifies the existing batch write helper routes through the new async write extensions.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ValueBatchWrite_WhenCalled_UsesAsyncWriteExtensions()
+    {
+        var plc = new TestPlc();
+
+        await plc.ValueBatch(new Dictionary<string, ushort> { ["A"] = 12 });
+
+        Assert.That(plc.WrittenValues["A"], Is.EqualTo((ushort)12));
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Verifies async observable value projections emit tag updates.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ObserveValueAsync_WhenTagChanges_EmitsUpdatedValue()
+    {
+        var plc = new TestPlc();
+        plc.TagList.Add(new Tag("A", "DB1.DBW0", typeof(ushort)));
+
+        var completion = new TaskCompletionSource<ushort>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var subscription = await plc.ObserveValueAsync<ushort>("A")
+            .SubscribeAsync(
+                async (value, cancellationToken) =>
+                {
+                    if (value == 123)
+                    {
+                        completion.TrySetResult(value);
+                    }
+
+                    await Task.CompletedTask;
+                },
+                CancellationToken.None);
+
+        plc.PublishObservedValue("A", (ushort)123, typeof(ushort));
+
+        var result = await completion.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.That(result, Is.EqualTo((ushort)123));
+    }
+
+    /// <summary>
+    /// Verifies async observable single-value wrappers reject blank variable names.
+    /// </summary>
+    [Test]
+    public void ObserveValueAsync_WhenVariableBlank_ThrowsArgumentNullException()
+    {
+        var plc = new TestPlc();
+
+        Assert.Throws<ArgumentNullException>(() => plc.ObserveValueAsync<ushort>(string.Empty));
+    }
+
+    /// <summary>
+    /// Verifies async observable batch projections emit updated dictionaries.
+    /// </summary>
+    /// <returns>A task representing the test operation.</returns>
+    [Test]
+    public async Task ObserveValuesAsync_WhenTagsChange_EmitsUpdatedDictionary()
+    {
+        var plc = new TestPlc();
+        plc.TagList.Add(new Tag("A", "DB1.DBW0", typeof(ushort)));
+
+        var completion = new TaskCompletionSource<Dictionary<string, ushort>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var subscription = await plc.ObserveValuesAsync<ushort>("A")
+            .SubscribeAsync(
+                async (values, cancellationToken) =>
+                {
+                    if (values.TryGetValue("A", out var a) && a == 10)
+                    {
+                        completion.TrySetResult(values);
+                    }
+
+                    await Task.CompletedTask;
+                },
+                CancellationToken.None);
+
+        plc.PublishObservedValue("A", (ushort)10, typeof(ushort));
+
+        var values = await completion.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.That(values["A"], Is.EqualTo((ushort)10));
+    }
+
+    /// <summary>
+    /// Verifies async observable batch wrappers reject empty variable lists.
+    /// </summary>
+    [Test]
+    public void ObserveValuesAsync_WhenVariablesEmpty_ThrowsArgumentException()
+    {
+        var plc = new TestPlc();
+
+        Assert.Throws<ArgumentException>(() => plc.ObserveValuesAsync<ushort>());
+    }
+
+    /// <summary>
+    /// Verifies async observable batch wrappers reject null variable arrays.
+    /// </summary>
+    [Test]
+    public void ObserveValuesAsync_WhenVariablesNull_ThrowsArgumentNullException()
+    {
+        var plc = new TestPlc();
+
+        Assert.Throws<ArgumentNullException>(() => plc.ObserveValuesAsync<ushort>(null!));
+    }
+#endif
+
+    private sealed class TestPlc : IRxS7
+    {
+        private readonly Dictionary<string, object?> _asyncValues = new(StringComparer.InvariantCultureIgnoreCase);
+        private readonly Dictionary<string, Func<CancellationToken, Task<object?>>> _asyncValueFactories = new(StringComparer.InvariantCultureIgnoreCase);
+        private readonly Subject<Tag?> _observeAllSubject = new();
+        private readonly Dictionary<string, object?> _syncValues = new(StringComparer.InvariantCultureIgnoreCase);
+
+        public string IP => MockServer.Localhost;
+
+        public IObservable<bool> IsConnected => Observable.Return(true);
+
+        public bool IsConnectedValue => true;
+
+        public IObservable<string> LastError => Observable.Empty<string>();
+
+        public IObservable<ErrorCode> LastErrorCode => Observable.Empty<ErrorCode>();
+
+        public IObservable<Tag?> ObserveAll => _observeAllSubject.AsObservable();
+
+        public CpuType PLCType => CpuType.S71500;
+
+        public short Rack => 0;
+
+        public short Slot => 1;
+
+        public IObservable<bool> IsPaused => Observable.Return(false);
+
+        public IObservable<string> Status => Observable.Empty<string>();
+
+        public Tags TagList { get; } = [];
+
+        public bool ShowWatchDogWriting { get; set; }
+
+        public string? WatchDogAddress => null;
+
+        public ushort WatchDogValueToWrite { get; set; }
+
+        public int WatchDogWritingTime => 0;
+
+        public IObservable<long> ReadTime => Observable.Empty<long>();
+
+        public int AsyncReadCount { get; private set; }
+
+        public bool IsDisposed { get; private set; }
+
+        public int SyncReadCount { get; private set; }
+
+        public Dictionary<string, object?> WrittenValues { get; } = new(StringComparer.InvariantCultureIgnoreCase);
+
+        public void Dispose()
+        {
+            IsDisposed = true;
+            _observeAllSubject.Dispose();
+        }
+
+        public IObservable<T?> Observe<T>(string? variable) => _observeAllSubject
+            .Where(tag => string.Equals(tag?.Name, variable, StringComparison.InvariantCultureIgnoreCase))
+            .Where(tag => tag?.Value is T)
+            .Select(tag => (T?)tag!.Value);
+
+        public Task<T?> Value<T>(string? variable)
+        {
+            SyncReadCount++;
+            return Task.FromResult(ReadValue<T>(variable, _syncValues));
+        }
+
+        public Task<T?> ValueAsync<T>(string? variable, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AsyncReadCount++;
+            if (_asyncValueFactories.TryGetValue(variable!, out var factory))
+            {
+                return ReadFromFactoryAsync<T>(factory, cancellationToken);
+            }
+
+            return Task.FromResult(ReadValue<T>(variable, _asyncValues));
+        }
+
+        public void Value<T>(string? variable, T? value)
+        {
+            WrittenValues[variable!] = value;
+        }
+
+        public IObservable<string[]> GetCpuInfo() => Observable.Return(Array.Empty<string>());
+
+        public void SetAsyncFactory(string variable, Func<CancellationToken, Task<object?>> factory)
+            => _asyncValueFactories[variable] = factory;
+
+        public void SetAsyncValue(string variable, object value)
+            => _asyncValues[variable] = value;
+
+        public void SetSyncValue(string variable, object value)
+            => _syncValues[variable] = value;
+
+        public void PublishObservedValue(string variable, object? value, Type type)
+        {
+            if (string.IsNullOrWhiteSpace(variable))
+            {
+                throw new ArgumentNullException(nameof(variable));
+            }
+
+            var tag = TagList[variable] ?? new Tag(variable, variable, type);
+            tag.Value = value;
+
+            if (TagList[variable] == null)
+            {
+                TagList.Add(tag);
+            }
+
+            _observeAllSubject.OnNext(tag);
+        }
+
+        private static async Task<T?> ReadFromFactoryAsync<T>(Func<CancellationToken, Task<object?>> factory, CancellationToken cancellationToken)
+        {
+            var value = await factory(cancellationToken);
+            return value is T typed ? typed : default;
+        }
+
+        private static T? ReadValue<T>(string? variable, IReadOnlyDictionary<string, object?> values)
+        {
+            if (string.IsNullOrWhiteSpace(variable))
+            {
+                throw new ArgumentNullException(nameof(variable));
+            }
+
+            return values.TryGetValue(variable, out var value) && value is T typed ? typed : default;
+        }
+    }
+}

--- a/src/S7PlcRx/Advanced/AdvancedExtensions.cs
+++ b/src/S7PlcRx/Advanced/AdvancedExtensions.cs
@@ -88,71 +88,7 @@ public static class AdvancedExtensions
             throw new ArgumentNullException(nameof(plc), "PLC instance cannot be null.");
         }
 
-        if (variables == null || variables.Length == 0)
-        {
-            return [];
-        }
-
-        if (plc is RxS7 rx)
-        {
-            var tags = variables
-                .Select(v => rx.TagList[v])
-                .Where(t => t != null)
-                .ToList();
-
-            if (tags?.Count == variables.Length)
-            {
-                var multi = rx.ReadMultiVar(tags!);
-                if (multi != null)
-                {
-                    var dict = new Dictionary<string, T?>(multi.Count);
-                    foreach (var kvp in multi)
-                    {
-                        if (kvp.Value is null)
-                        {
-                            dict[kvp.Key] = default;
-                            continue;
-                        }
-
-                        if (kvp.Value is T typed)
-                        {
-                            dict[kvp.Key] = typed;
-                        }
-                        else
-                        {
-                            // Type mismatch (e.g. T=object). Use fallback path.
-                            dict = null;
-                            break;
-                        }
-                    }
-
-                    if (dict != null)
-                    {
-                        return dict;
-                    }
-                }
-            }
-        }
-
-        var results = new Dictionary<string, T?>();
-        var tasks = new List<Task<T?>>();
-
-        // Create tasks for each variable read
-        foreach (var variable in variables)
-        {
-            tasks.Add(plc.Value<T>(variable));
-        }
-
-        // Wait for all reads to complete
-        var values = await Task.WhenAll(tasks);
-
-        // Combine results
-        for (var i = 0; i < variables.Length; i++)
-        {
-            results[variables[i]] = values[i];
-        }
-
-        return results;
+        return await plc.ReadValuesAsync<T>(variables).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -172,27 +108,12 @@ public static class AdvancedExtensions
             return;
         }
 
-        if (plc is RxS7 rx)
+        if (plc == null)
         {
-            var tags = values
-                .Select(kvp =>
-                {
-                    var t = rx.TagList[kvp.Key];
-                    t?.NewValue = kvp.Value;
-
-                    return t;
-                })
-                .Where(t => t != null)
-                .ToList();
-
-            if (tags?.Count == values.Count && rx.WriteMultiVar(tags!))
-            {
-                return;
-            }
+            throw new ArgumentNullException(nameof(plc), "PLC instance cannot be null.");
         }
 
-        var tasks = values.Select(kvp => Task.Run(() => plc.Value(kvp.Key, kvp.Value))).ToArray();
-        await Task.WhenAll(tasks);
+        await plc.WriteValuesAsync(values).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/S7PlcRx/Advanced/AsyncExtensions.cs
+++ b/src/S7PlcRx/Advanced/AsyncExtensions.cs
@@ -1,0 +1,337 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using ReactiveUI.Extensions;
+#if NET8_0_OR_GREATER
+using ReactiveUI.Extensions.Async;
+#endif
+
+namespace S7PlcRx.Advanced;
+
+/// <summary>
+/// Provides additional async-first helpers for reading, writing, and observing PLC values without changing the base
+/// <see cref="IRxS7"/> API surface.
+/// </summary>
+/// <remarks>These helpers layer <see cref="ValueTask"/> and async-observable patterns over the existing PLC API.
+/// Where possible, they complete synchronously from cached tag values or the existing multi-variable read/write paths
+/// to reduce avoidable allocations.</remarks>
+public static class AsyncExtensions
+{
+    /// <summary>
+    /// Reads a PLC value using a <see cref="ValueTask{TResult}"/>, returning synchronously when a compatible cached tag value is already available.
+    /// </summary>
+    /// <typeparam name="T">The expected PLC value type.</typeparam>
+    /// <param name="plc">The PLC instance.</param>
+    /// <param name="variable">The tag name to read.</param>
+    /// <param name="cancellationToken">The cancellation token for the read operation.</param>
+    /// <returns>A <see cref="ValueTask{TResult}"/> that resolves to the current PLC value.</returns>
+    public static ValueTask<T?> ReadValueAsync<T>(this IRxS7 plc, string? variable, CancellationToken cancellationToken = default)
+    {
+        if (plc == null)
+        {
+            throw new ArgumentNullException(nameof(plc));
+        }
+
+        if (string.IsNullOrWhiteSpace(variable))
+        {
+            throw new ArgumentNullException(nameof(variable));
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return new ValueTask<T?>(Task.FromCanceled<T?>(cancellationToken));
+        }
+
+        if (TryGetCurrentValue(plc, variable, out T? currentValue))
+        {
+            return new ValueTask<T?>(currentValue);
+        }
+
+        return cancellationToken.CanBeCanceled
+            ? new ValueTask<T?>(plc.ValueAsync<T>(variable, cancellationToken))
+            : new ValueTask<T?>(plc.Value<T>(variable));
+    }
+
+    /// <summary>
+    /// Reads multiple PLC values using a <see cref="ValueTask{TResult}"/>, preferring cached values and the optimized multi-variable read path where available.
+    /// </summary>
+    /// <typeparam name="T">The expected PLC value type.</typeparam>
+    /// <param name="plc">The PLC instance.</param>
+    /// <param name="variables">The tag names to read.</param>
+    /// <returns>A <see cref="ValueTask{TResult}"/> that resolves to a dictionary of tag values keyed by tag name.</returns>
+    public static ValueTask<Dictionary<string, T?>> ReadValuesAsync<T>(this IRxS7 plc, params string[] variables)
+        => ReadValuesAsync<T>(plc, (IReadOnlyList<string>)variables, CancellationToken.None);
+
+    /// <summary>
+    /// Reads multiple PLC values using a <see cref="ValueTask{TResult}"/>, honoring cancellation for deferred reads.
+    /// </summary>
+    /// <typeparam name="T">The expected PLC value type.</typeparam>
+    /// <param name="plc">The PLC instance.</param>
+    /// <param name="variables">The tag names to read.</param>
+    /// <param name="cancellationToken">The cancellation token for deferred reads.</param>
+    /// <returns>A <see cref="ValueTask{TResult}"/> that resolves to a dictionary of tag values keyed by tag name.</returns>
+    public static ValueTask<Dictionary<string, T?>> ReadValuesAsync<T>(this IRxS7 plc, IReadOnlyList<string> variables, CancellationToken cancellationToken = default)
+    {
+        if (plc == null)
+        {
+            throw new ArgumentNullException(nameof(plc));
+        }
+
+        if (variables == null)
+        {
+            throw new ArgumentNullException(nameof(variables));
+        }
+
+        if (variables.Count == 0)
+        {
+            return new ValueTask<Dictionary<string, T?>>(new Dictionary<string, T?>());
+        }
+
+        foreach (var variable in variables)
+        {
+            if (string.IsNullOrWhiteSpace(variable))
+            {
+                throw new ArgumentNullException(nameof(variables));
+            }
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return new ValueTask<Dictionary<string, T?>>(Task.FromCanceled<Dictionary<string, T?>>(cancellationToken));
+        }
+
+        if (TryGetCurrentValues<T>(plc, variables, out var cachedValues))
+        {
+            return new ValueTask<Dictionary<string, T?>>(cachedValues);
+        }
+
+        if (plc is RxS7 rx && TryReadMultiVar<T>(rx, variables, out var multiValues))
+        {
+            return new ValueTask<Dictionary<string, T?>>(multiValues);
+        }
+
+        var pendingReads = new Task<T?>[variables.Count];
+        for (var i = 0; i < variables.Count; i++)
+        {
+            pendingReads[i] = cancellationToken.CanBeCanceled
+                ? plc.ValueAsync<T>(variables[i], cancellationToken)
+                : plc.Value<T>(variables[i]);
+        }
+
+        if (pendingReads.All(static read => read.Status == TaskStatus.RanToCompletion))
+        {
+            var values = new Dictionary<string, T?>(variables.Count, StringComparer.InvariantCultureIgnoreCase);
+            for (var i = 0; i < variables.Count; i++)
+            {
+                values[variables[i]] = pendingReads[i].Result;
+            }
+
+            return new ValueTask<Dictionary<string, T?>>(values);
+        }
+
+        return new ValueTask<Dictionary<string, T?>>(ReadValuesAsyncCore(variables, pendingReads));
+    }
+
+    /// <summary>
+    /// Writes multiple PLC values using a <see cref="ValueTask"/>, preferring the optimized multi-variable write path where available.
+    /// </summary>
+    /// <typeparam name="T">The PLC value type.</typeparam>
+    /// <param name="plc">The PLC instance.</param>
+    /// <param name="values">The tag values to write.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A completed <see cref="ValueTask"/> when the writes have been issued.</returns>
+    public static ValueTask WriteValuesAsync<T>(this IRxS7 plc, IReadOnlyDictionary<string, T> values, CancellationToken cancellationToken = default)
+    {
+        if (plc == null)
+        {
+            throw new ArgumentNullException(nameof(plc));
+        }
+
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        if (values.Count == 0)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (plc is RxS7 rx && TryWriteMultiVar(rx, values))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        foreach (var kvp in values)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            plc.Value(kvp.Key, kvp.Value);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Exposes a PLC variable as an async observable sequence.
+    /// </summary>
+    /// <typeparam name="T">The expected PLC value type.</typeparam>
+    /// <param name="plc">The PLC instance.</param>
+    /// <param name="variable">The tag name to observe.</param>
+    /// <returns>An <see cref="IObservableAsync{T}"/> that emits tag value updates asynchronously.</returns>
+    public static IObservableAsync<T?> ObserveValueAsync<T>(this IRxS7 plc, string? variable)
+    {
+        if (plc == null)
+        {
+            throw new ArgumentNullException(nameof(plc));
+        }
+
+        if (string.IsNullOrWhiteSpace(variable))
+        {
+            throw new ArgumentNullException(nameof(variable));
+        }
+
+        return plc.Observe<T>(variable).ToObservableAsync();
+    }
+
+    /// <summary>
+    /// Exposes a batch PLC observation as an async observable sequence.
+    /// </summary>
+    /// <typeparam name="T">The expected PLC value type.</typeparam>
+    /// <param name="plc">The PLC instance.</param>
+    /// <param name="variables">The tag names to observe.</param>
+    /// <returns>An <see cref="IObservableAsync{T}"/> that emits dictionaries of tag values asynchronously.</returns>
+    public static IObservableAsync<Dictionary<string, T?>> ObserveValuesAsync<T>(this IRxS7 plc, params string[] variables)
+    {
+        if (plc == null)
+        {
+            throw new ArgumentNullException(nameof(plc));
+        }
+
+        if (variables == null)
+        {
+            throw new ArgumentNullException(nameof(variables));
+        }
+
+        if (variables.Length == 0)
+        {
+            throw new ArgumentException("At least one variable is required.", nameof(variables));
+        }
+
+        foreach (var variable in variables)
+        {
+            if (string.IsNullOrWhiteSpace(variable))
+            {
+                throw new ArgumentNullException(nameof(variables));
+            }
+        }
+
+        return plc.ObserveBatch<T>(variables).ToObservableAsync();
+    }
+#endif
+
+    private static async Task<Dictionary<string, T?>> ReadValuesAsyncCore<T>(IReadOnlyList<string> variables, Task<T?>[] pendingReads)
+    {
+        var values = new Dictionary<string, T?>(variables.Count, StringComparer.InvariantCultureIgnoreCase);
+        for (var i = 0; i < variables.Count; i++)
+        {
+            values[variables[i]] = await pendingReads[i].ConfigureAwait(false);
+        }
+
+        return values;
+    }
+
+    private static bool TryGetCurrentValue<T>(IRxS7 plc, string variable, out T? value)
+    {
+        var tag = plc.TagList[variable];
+        if (tag != null && (typeof(T) == typeof(object) || (tag.Type == typeof(T) && tag.Value?.GetType() == typeof(T))))
+        {
+            value = (T?)tag.Value;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TryGetCurrentValues<T>(IRxS7 plc, IReadOnlyList<string> variables, out Dictionary<string, T?> values)
+    {
+        values = new Dictionary<string, T?>(variables.Count, StringComparer.InvariantCultureIgnoreCase);
+        foreach (var variable in variables)
+        {
+            if (!TryGetCurrentValue(plc, variable, out T? value))
+            {
+                values = null!;
+                return false;
+            }
+
+            values[variable] = value;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadMultiVar<T>(RxS7 rx, IReadOnlyList<string> variables, out Dictionary<string, T?> values)
+    {
+        var tags = new List<Tag>(variables.Count);
+        foreach (var variable in variables)
+        {
+            var tag = rx.TagList[variable];
+            if (tag == null)
+            {
+                values = null!;
+                return false;
+            }
+
+            tags.Add(tag);
+        }
+
+        var multi = rx.ReadMultiVar(tags);
+        if (multi == null)
+        {
+            values = null!;
+            return false;
+        }
+
+        values = new Dictionary<string, T?>(multi.Count, StringComparer.InvariantCultureIgnoreCase);
+        foreach (var kvp in multi)
+        {
+            if (kvp.Value is null)
+            {
+                values[kvp.Key] = default;
+                continue;
+            }
+
+            if (kvp.Value is T typed)
+            {
+                values[kvp.Key] = typed;
+                continue;
+            }
+
+            values = null!;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryWriteMultiVar<T>(RxS7 rx, IReadOnlyDictionary<string, T> values)
+    {
+        var tags = new List<Tag>(values.Count);
+        foreach (var kvp in values)
+        {
+            var tag = rx.TagList[kvp.Key];
+            if (tag == null)
+            {
+                return false;
+            }
+
+            tag.NewValue = kvp.Value;
+            tags.Add(tag);
+        }
+
+        return rx.WriteMultiVar(tags);
+    }
+}

--- a/src/S7PlcRx/Core/S7SocketRx.cs
+++ b/src/S7PlcRx/Core/S7SocketRx.cs
@@ -927,7 +927,7 @@ internal class S7SocketRx : IDisposable
 
                 var server = new IPEndPoint(IPAddress.Parse(IP), 102);
 
-#if NETSTANDARD2_0
+#if NETFRAMEWORK
                 var connectTask = Task.Factory.FromAsync(
                     (callback, state) => attemptSocket.BeginConnect(server, callback, state),
                     attemptSocket.EndConnect,
@@ -998,7 +998,7 @@ internal class S7SocketRx : IDisposable
         var bReceive = _bufferPool.Rent(256);
         try
         {
-#if NETSTANDARD2_0
+#if NETFRAMEWORK
             return await PerformOptimizedHandshakeNetStandardAsync(socket, bReceive, profile).ConfigureAwait(false);
 #else
             return await PerformOptimizedHandshakeModernAsync(socket, bReceive, profile).ConfigureAwait(false);
@@ -1010,7 +1010,7 @@ internal class S7SocketRx : IDisposable
         }
     }
 
-#if NETSTANDARD2_0
+#if NETFRAMEWORK
     private async Task<bool> PerformOptimizedHandshakeNetStandardAsync(Socket socket, byte[] bReceive, TsapProfile profile)
     {
         try
@@ -1651,7 +1651,7 @@ internal class S7SocketRx : IDisposable
         try
         {
             var server = new IPEndPoint(IPAddress.Parse(IP), 102);
-#if NETSTANDARD2_0
+#if NETFRAMEWORK
             var connectTask = Task.Factory.FromAsync(
                 (callback, state) => probeSocket.BeginConnect(server, callback, state),
                 probeSocket.EndConnect,

--- a/src/S7PlcRx/PlcTypes/ByteArray.cs
+++ b/src/S7PlcRx/PlcTypes/ByteArray.cs
@@ -11,7 +11,7 @@ namespace S7PlcRx.PlcTypes;
 /// <remarks>The buffer automatically grows as data is added. The internal array is rented from the shared array
 /// pool and returned when disposed. This class is not thread-safe.</remarks>
 /// <param name="size">The initial capacity of the internal buffer, in bytes. Must be greater than zero.</param>
-internal class ByteArray(int size) : IDisposable
+public class ByteArray(int size) : IDisposable
 {
     private byte[] _buffer = ArrayPool<byte>.Shared.Rent(size);
     private int _position;
@@ -88,7 +88,15 @@ internal class ByteArray(int size) : IDisposable
     /// Adds the contents of the specified <see cref="ByteArray"/> to the collection.
     /// </summary>
     /// <param name="byteArray">The <see cref="ByteArray"/> instance whose contents will be added. Cannot be null.</param>
-    public void Add(ByteArray byteArray) => Add(byteArray.Span);
+    public void Add(ByteArray byteArray)
+    {
+        if (byteArray == null)
+        {
+            throw new ArgumentNullException(nameof(byteArray));
+        }
+
+        Add(byteArray.Span);
+    }
 
     /// <summary>
     /// Resets the current position to the beginning, effectively clearing any progress or state tracked by the

--- a/src/S7PlcRx/PlcTypes/DInt.cs
+++ b/src/S7PlcRx/PlcTypes/DInt.cs
@@ -14,7 +14,7 @@ namespace S7PlcRx.PlcTypes;
 /// values. Methods are provided for reading and writing single or multiple DInt values from and to byte arrays and
 /// spans. All methods assume S7 DInt format and handle endianness as required. This class is intended for internal use
 /// when working with S7 PLC data structures.</remarks>
-internal static class DInt
+public static class DInt
 {
     /// <summary>
     /// Converts a 64-bit signed integer to a 32-bit signed integer, applying a custom transformation for values greater
@@ -196,5 +196,13 @@ internal static class DInt
     /// <param name="value">An array of 32-bit integers to convert. Cannot be null.</param>
     /// <returns>A byte array containing the binary representation of the input integer array. The length of the returned array
     /// is four times the length of the input array.</returns>
-    public static byte[] ToByteArray(int[] value) => TypeConverter.ToByteArray(value, ToByteArray);
+    public static byte[] ToByteArray(int[] value)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        return TypeConverter.ToByteArray(value, ToByteArray);
+    }
 }

--- a/src/S7PlcRx/PlcTypes/DWord.cs
+++ b/src/S7PlcRx/PlcTypes/DWord.cs
@@ -13,7 +13,7 @@ namespace S7PlcRx.PlcTypes;
 /// <remarks>All conversions assume S7 DWord format, which uses big-endian byte order. These methods are intended
 /// for working with Siemens S7 PLC data or other protocols that represent 32-bit unsigned integers in big-endian
 /// format. Methods throw exceptions if provided buffers are too small to contain a DWord value.</remarks>
-internal static class DWord
+public static class DWord
 {
     /// <summary>
     /// Creates a 32-bit unsigned integer from a byte array.
@@ -172,5 +172,13 @@ internal static class DWord
     /// <param name="value">An array of 32-bit unsigned integers to convert. Cannot be null.</param>
     /// <returns>A byte array containing the binary representation of the input values. The length of the returned array is four
     /// times the length of the input array.</returns>
-    public static byte[] ToByteArray(uint[] value) => TypeConverter.ToByteArray(value, ToByteArray);
+    public static byte[] ToByteArray(uint[] value)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        return TypeConverter.ToByteArray(value, ToByteArray);
+    }
 }

--- a/src/S7PlcRx/PlcTypes/Int.cs
+++ b/src/S7PlcRx/PlcTypes/Int.cs
@@ -13,7 +13,7 @@ namespace S7PlcRx.PlcTypes;
 /// <remarks>This class is intended for working with Siemens S7 PLC data formats, which use big-endian byte order
 /// for 16-bit signed integers. All methods assume S7 Int format unless otherwise specified. The class is internal and
 /// not intended for direct use outside of the containing assembly.</remarks>
-internal static class Int
+public static class Int
 {
     /// <summary>
     /// Converts a 32-bit signed integer to a 16-bit signed integer, applying a custom transformation for values greater
@@ -186,5 +186,13 @@ internal static class Int
     /// </summary>
     /// <param name="value">An array of 16-bit signed integers to convert. Cannot be null.</param>
     /// <returns>A byte array containing the binary representation of the input values.</returns>
-    public static byte[] ToByteArray(short[] value) => TypeConverter.ToByteArray(value, ToByteArray);
+    public static byte[] ToByteArray(short[] value)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value), "Input array cannot be null");
+        }
+
+        return TypeConverter.ToByteArray(value, ToByteArray);
+    }
 }

--- a/src/S7PlcRx/PlcTypes/LReal.cs
+++ b/src/S7PlcRx/PlcTypes/LReal.cs
@@ -14,7 +14,7 @@ namespace S7PlcRx.PlcTypes;
 /// .NET double values, including proper handling of endianness. All methods are static and intended for internal use
 /// when working with S7 protocol data. This class is not thread-safe, but all members are stateless and safe for
 /// concurrent use.</remarks>
-internal static class LReal
+public static class LReal
 {
     /// <summary>
     /// Converts a byte array to a double-precision floating-point number.
@@ -179,5 +179,13 @@ internal static class LReal
     /// <param name="value">The array of double values to convert. Cannot be null.</param>
     /// <returns>A byte array containing the binary representation of the input double array. The array will be empty if the
     /// input array is empty.</returns>
-    public static byte[] ToByteArray(double[] value) => TypeConverter.ToByteArray(value, ToByteArray);
+    public static byte[] ToByteArray(double[] value)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        return TypeConverter.ToByteArray(value, ToByteArray);
+    }
 }

--- a/src/S7PlcRx/PlcTypes/Real.cs
+++ b/src/S7PlcRx/PlcTypes/Real.cs
@@ -13,7 +13,7 @@ namespace S7PlcRx.PlcTypes;
 /// <remarks>The methods in this class handle endianness according to the S7 protocol, which uses big-endian byte
 /// order. Use these methods to serialize and deserialize float values when communicating with Siemens S7 PLCs or
 /// working with S7 Real data formats. All methods are static and intended for internal use.</remarks>
-internal static class Real
+public static class Real
 {
     /// <summary>
     /// Converts a byte array to a single-precision floating-point value.
@@ -99,7 +99,15 @@ internal static class Real
     /// </summary>
     /// <param name="value">The array of <see cref="float"/> values to convert. Cannot be null.</param>
     /// <returns>A byte array containing the binary representation of the input values.</returns>
-    public static byte[] ToByteArray(float[] value) => TypeConverter.ToByteArray(value, ToByteArray);
+    public static byte[] ToByteArray(float[] value)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value), "Input array cannot be null");
+        }
+
+        return TypeConverter.ToByteArray(value, ToByteArray);
+    }
 
     /// <summary>
     /// Converts a span of single-precision floating-point values to their byte representations and writes them to the

--- a/src/S7PlcRx/PlcTypes/String.cs
+++ b/src/S7PlcRx/PlcTypes/String.cs
@@ -11,7 +11,7 @@ namespace S7PlcRx.PlcTypes;
 /// <remarks>All methods in this class use ASCII encoding for conversions. These methods are intended for
 /// scenarios where data is known to be ASCII-compatible. Non-ASCII characters will be replaced with '?' during encoding
 /// and decoding. The class is internal and intended for use within the assembly.</remarks>
-internal static class String
+public static class String
 {
     /// <summary>
     /// Decodes a UTF-8 encoded byte array into a string.
@@ -33,12 +33,7 @@ internal static class String
             return string.Empty;
         }
 
-#if NETSTANDARD2_0
-        // Encoding APIs do not accept spans on netstandard2.0.
-        return Encoding.ASCII.GetString(bytes.ToArray());
-#else
         return Encoding.ASCII.GetString(bytes);
-#endif
     }
 
     /// <summary>
@@ -51,6 +46,11 @@ internal static class String
     /// the array.</returns>
     public static string FromByteArray(byte[] bytes, int start, int length)
     {
+        if (bytes == null || bytes.Length == 0)
+        {
+            return string.Empty;
+        }
+
         if (bytes.Length < start + length)
         {
             return string.Empty;
@@ -94,23 +94,12 @@ internal static class String
             return 0;
         }
 
-#if NETSTANDARD2_0
-        var bytes = Encoding.ASCII.GetBytes(value);
-        if (bytes.Length > destination.Length)
-        {
-            throw new ArgumentException("Destination span is too small", nameof(destination));
-        }
-
-        bytes.AsSpan().CopyTo(destination);
-        return bytes.Length;
-#else
         if (!Encoding.ASCII.TryGetBytes(value, destination, out var bytesWritten))
         {
             throw new ArgumentException("Destination span is too small", nameof(destination));
         }
 
         return bytesWritten;
-#endif
     }
 
     /// <summary>
@@ -132,18 +121,6 @@ internal static class String
             return true;
         }
 
-#if NETSTANDARD2_0
-        var bytes = Encoding.ASCII.GetBytes(value);
-        if (bytes.Length > destination.Length)
-        {
-            return false;
-        }
-
-        bytes.AsSpan().CopyTo(destination);
-        bytesWritten = bytes.Length;
-        return true;
-#else
         return Encoding.ASCII.TryGetBytes(value, destination, out bytesWritten);
-#endif
     }
 }

--- a/src/S7PlcRx/PlcTypes/Timer.cs
+++ b/src/S7PlcRx/PlcTypes/Timer.cs
@@ -11,7 +11,7 @@ namespace S7PlcRx.PlcTypes;
 /// <remarks>This class is intended for working with Siemens S7 PLC timer values, enabling conversion to and from
 /// the S7-specific byte format and standard .NET types such as double and ushort. All members are static and the class
 /// cannot be instantiated.</remarks>
-internal static class Timer
+public static class Timer
 {
     /// <summary>
     /// Converts a byte array to a double-precision floating-point number.
@@ -183,5 +183,13 @@ internal static class Timer
     /// </summary>
     /// <param name="value">The array of 16-bit unsigned integers to convert. Cannot be null.</param>
     /// <returns>A byte array containing the binary representation of the input values.</returns>
-    public static byte[] ToByteArray(ushort[] value) => TypeConverter.ToByteArray(value, ToByteArray);
+    public static byte[] ToByteArray(ushort[] value)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        return TypeConverter.ToByteArray(value, ToByteArray);
+    }
 }

--- a/src/S7PlcRx/PlcTypes/Word.cs
+++ b/src/S7PlcRx/PlcTypes/Word.cs
@@ -13,7 +13,7 @@ namespace S7PlcRx.PlcTypes;
 /// byte is the high-order byte and the second byte is the low-order byte. These methods are intended for scenarios
 /// where explicit control over byte order is required, such as binary serialization, communication protocols, or file
 /// I/O. The class is static and cannot be instantiated.</remarks>
-internal static class Word
+public static class Word
 {
     /// <summary>
     /// Creates a 16-bit unsigned integer from a byte array.
@@ -134,7 +134,15 @@ internal static class Word
     /// </summary>
     /// <param name="value">The array of 16-bit unsigned integers to convert. Cannot be null.</param>
     /// <returns>A byte array containing the binary representation of the input values.</returns>
-    public static byte[] ToByteArray(ushort[] value) => TypeConverter.ToByteArray(value, ToByteArray);
+    public static byte[] ToByteArray(ushort[] value)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value), "Input array cannot be null");
+        }
+
+        return TypeConverter.ToByteArray(value, ToByteArray);
+    }
 
     /// <summary>
     /// Converts a sequence of 16-bit unsigned integers to their byte representation and writes the result to the

--- a/src/S7PlcRx/RxS7.cs
+++ b/src/S7PlcRx/RxS7.cs
@@ -847,15 +847,8 @@ public class RxS7 : IRxS7
     /// <paramref name="s"/>, if the conversion succeeded, or zero if the conversion failed. This parameter is passed
     /// uninitialized.</param>
     /// <returns><see langword="true"/> if the conversion succeeded; otherwise, <see langword="false"/>.</returns>
-    private static bool TryParseInt(ReadOnlySpan<char> s, out int value)
-    {
-#if NETSTANDARD2_0
-        value = 0;
-        return int.TryParse(s.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
-#else
-        return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
-#endif
-    }
+    private static bool TryParseInt(ReadOnlySpan<char> s, out int value) =>
+        int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
 
     /// <summary>
     /// Attempts to parse a data block address for a multi-variable tag and extract its components.

--- a/src/S7PlcRx/S7PlcRx.csproj
+++ b/src/S7PlcRx/S7PlcRx.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net481;net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);IDE0042</NoWarn>
   </PropertyGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">    
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
-    <PackageReference Include="Polyfill" Version="10.0.0">
+
+  <ItemGroup Condition=" $([System.String]::new('$(TargetFramework)').StartsWith('net4')) ">
+    <PackageReference Include="System.Text.Json" Version="10.0.6" />
+    <PackageReference Include="Polyfill" Version="10.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -16,6 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="ReactiveUI.Extensions" Version="2.3.1" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Introduce async-first helpers and tests, and modernize several internal APIs:

- Add S7PlcRx.Advanced.AsyncExtensions: ValueTask-based ReadValueAsync/ReadValuesAsync/WriteValuesAsync and NET8+ async observable wrappers with optimized multi-var handling.
- Add comprehensive unit tests in S7PlcRx.Tests/S7PlcRxAsyncExtensionsTests.cs exercising async reads/writes/observables and a TestPlc mock.
- Simplify AdvancedExtensions to delegate to the new async helpers.
- Update S7PlcRx.TestApp.csproj to reference MockS7Plc and copy native snap7.dlls to output.
- Change S7PlcRx.csproj target frameworks to include .NET Framework (net462/net472/net481) alongside net8+/net9+/net10 and update package references (System.Text.Json, Polyfill) and add ReactiveUI.Extensions.
- Adjust S7SocketRx conditional compilation symbol from NETSTANDARD2_0 to NETFRAMEWORK for handshake/connect code paths.
- Make several PlcTypes classes public and add argument validation (ByteArray, DInt, DWord, Int, LReal, Real, String, Timer, Word) and minor API/safety improvements.
- Simplify TryParseInt implementation in RxS7.

These changes provide an async-friendly surface, improve robustness via input validation, and broaden framework support and package compatibility.