### PR TITLE
fix: restore S7 connection readiness after setup

### DIFF
--- a/src/S7PlcRx.Tests/S7PlcRx.Tests.csproj
+++ b/src/S7PlcRx.Tests/S7PlcRx.Tests.csproj
@@ -8,6 +8,7 @@
     <IsTestProject>true</IsTestProject>
     <PlatformTarget>x86</PlatformTarget>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <TUnitAssertionsImplicitUsings>false</TUnitAssertionsImplicitUsings>
   </PropertyGroup>
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <TargetFrameworks>net8.0</TargetFrameworks>
@@ -20,6 +21,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="TUnit.Assertions" Version="1.55.2" Aliases="TUnitAssertions" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 

--- a/src/S7PlcRx.Tests/S7PlcRxConnectionRegressionTests.cs
+++ b/src/S7PlcRx.Tests/S7PlcRxConnectionRegressionTests.cs
@@ -1,0 +1,347 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias TUnitAssertions;
+
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Reactive.Linq;
+using MockS7Plc;
+using S7PlcRx.Enums;
+using TUnitAssertions::TUnit.Assertions.Extensions;
+using TUnitAssert = TUnitAssertions::TUnit.Assertions.Assert;
+
+namespace S7PlcRx.Tests;
+
+/// <summary>
+/// Regression tests for connection readiness and watchdog behavior.
+/// </summary>
+[NonParallelizable]
+public sealed class S7PlcRxConnectionRegressionTests
+{
+    private const string LivePlcIp = "172.16.13.1";
+
+    /// <summary>
+    /// Ensures connection readiness is based on the completed ISO/S7 setup handshake, not optional SZL diagnostics.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsConnected_WhenSetupHandshakeSucceedsWithoutSzlReadiness_ShouldBecomeTrue()
+    {
+        using var server = new HandshakeOnlyS7Server();
+        using var plc = S71500.Create(MockServer.Localhost, 0, 1, null, interval: 50);
+
+        var connected = await plc.IsConnected
+            .Where(static x => x)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(5))
+            .FirstAsync();
+
+        await TUnitAssert.That(connected).IsTrue();
+        await TUnitAssert.That(server.HandshakeCount).IsGreaterThanOrEqualTo(1);
+        await TUnitAssert.That(server.UnsupportedRequestCount).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Ensures handshake frames can arrive fragmented across multiple TCP reads.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task IsConnected_WhenHandshakeResponsesAreFragmented_ShouldBecomeTrue()
+    {
+        using var server = new HandshakeOnlyS7Server(fragmentHandshakeResponses: true);
+        using var plc = S71500.Create(MockServer.Localhost, 0, 1, null, interval: 50);
+
+        var connected = await plc.IsConnected
+            .Where(static x => x)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(5))
+            .FirstAsync();
+
+        await TUnitAssert.That(connected).IsTrue();
+        await TUnitAssert.That(server.HandshakeCount).IsGreaterThanOrEqualTo(1);
+        await TUnitAssert.That(server.UnsupportedRequestCount).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Ensures a live S7-1500 can reach connected state without any program-specific DB reads.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [Explicit]
+    [Category("LivePLC")]
+    public async Task IsConnected_ToLiveS71500_ShouldBecomeTrue()
+    {
+        using var plc = S71500.Create(LivePlcIp, interval: 50);
+
+        var connected = await plc.IsConnected
+            .Where(static x => x)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(15))
+            .FirstAsync();
+
+        await TUnitAssert.That(connected).IsTrue();
+    }
+
+    /// <summary>
+    /// Ensures live CPU diagnostics complete without any program-specific DB reads.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [Explicit]
+    [Category("LivePLC")]
+    public async Task GetCpuInfo_ToLiveS71500_ShouldCompleteAndReturnIdentityFields()
+    {
+        using var plc = S71500.Create(LivePlcIp, interval: 50);
+
+        var cpuInfo = await plc.GetCpuInfo()
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(15))
+            .FirstAsync();
+
+        await TUnitAssert.That(cpuInfo).IsNotNull();
+        await TUnitAssert.That(cpuInfo.Length).IsGreaterThanOrEqualTo(9);
+        await TUnitAssert.That(cpuInfo.Any(static value => !string.IsNullOrWhiteSpace(value))).IsTrue();
+        await TUnitAssert.That(cpuInfo[5]).IsNotNull();
+        await TUnitAssert.That(cpuInfo[5].Trim()).IsNotEmpty();
+    }
+
+    /// <summary>
+    /// Ensures watchdog writes start once a normal MockS7Plc connection is established.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Watchdog_WhenConnectedToMockPlc_ShouldWriteConfiguredWord()
+    {
+        const ushort watchdogValue = 1234;
+
+        using var server = new MockServer();
+        server.DefaultDb1Size = 16;
+        await TUnitAssert.That(server.Start()).IsEqualTo(0);
+
+        using var plc = new RxS7(CpuType.S71500, MockServer.Localhost, 0, 1, "DB1.DBW0", interval: 50, watchdogValue, watchDogInterval: 1);
+
+        var connected = await plc.IsConnected
+            .Where(static x => x)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(10))
+            .FirstAsync();
+
+        await TUnitAssert.That(connected).IsTrue();
+
+        var watchdogWritten = await WaitUntilAsync(
+            () => BinaryPrimitives.ReadUInt16BigEndian(server.DefaultDb1!.AsSpan(0, 2)) == watchdogValue,
+            TimeSpan.FromSeconds(5));
+
+        await TUnitAssert.That(watchdogWritten).IsTrue();
+        await TUnitAssert.That(BinaryPrimitives.ReadUInt16BigEndian(server.DefaultDb1!.AsSpan(0, 2))).IsEqualTo(watchdogValue);
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate())
+            {
+                return true;
+            }
+
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        return predicate();
+    }
+
+    private sealed class HandshakeOnlyS7Server : IDisposable
+    {
+        private static readonly byte[] ConnectionConfirm =
+        [
+            0x03, 0x00, 0x00, 0x16, 0x11, 0xD0, 0x00, 0x01, 0x00, 0x2E, 0x00,
+            0xC0, 0x01, 0x09, 0xC1, 0x02, 0x03, 0x01, 0xC2, 0x02, 0x01, 0x00
+        ];
+
+        private static readonly byte[] SetupConfirm =
+        [
+            0x03, 0x00, 0x00, 0x1B, 0x02, 0xF0, 0x80, 0x32, 0x03, 0x00, 0x00,
+            0x04, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xF0, 0x00, 0x00, 0x03, 0xC0
+        ];
+
+        private static readonly byte[] UnsupportedDiagnosticResponse =
+        [
+            0x03, 0x00, 0x00, 0x10, 0x02, 0xF0, 0x80, 0x32,
+            0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        ];
+
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
+        private readonly TcpListener _listener;
+        private readonly Task _acceptLoop;
+        private readonly bool _fragmentHandshakeResponses;
+        private bool _disposed;
+        private int _handshakeCount;
+        private int _unsupportedRequestCount;
+
+        public HandshakeOnlyS7Server(bool fragmentHandshakeResponses = false)
+        {
+            _fragmentHandshakeResponses = fragmentHandshakeResponses;
+            _listener = new TcpListener(IPAddress.Loopback, 102);
+            _listener.Start();
+            _acceptLoop = AcceptLoopAsync();
+        }
+
+        public int HandshakeCount => Volatile.Read(ref _handshakeCount);
+
+        public int UnsupportedRequestCount => Volatile.Read(ref _unsupportedRequestCount);
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _cancellationTokenSource.Cancel();
+            _listener.Stop();
+            ((IDisposable)_listener).Dispose();
+
+            try
+            {
+                _acceptLoop.Wait(TimeSpan.FromSeconds(1));
+            }
+            catch (AggregateException)
+            {
+            }
+
+            _cancellationTokenSource.Dispose();
+        }
+
+        private static async Task<int> ReadTpktAsync(NetworkStream stream, byte[] buffer, CancellationToken cancellationToken)
+        {
+            if (!await ReadExactAsync(stream, buffer, 0, 4, cancellationToken).ConfigureAwait(false))
+            {
+                return 0;
+            }
+
+            var length = (buffer[2] << 8) | buffer[3];
+            if (length < 4 || length > buffer.Length)
+            {
+                return 0;
+            }
+
+            return await ReadExactAsync(stream, buffer, 4, length - 4, cancellationToken).ConfigureAwait(false)
+                ? length
+                : 0;
+        }
+
+        private static async Task<bool> ReadExactAsync(NetworkStream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var total = 0;
+            while (total < count)
+            {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+                var read = await stream.ReadAsync(buffer.AsMemory(offset + total, count - total), cancellationToken).ConfigureAwait(false);
+#else
+                var read = await stream.ReadAsync(buffer, offset + total, count - total, cancellationToken).ConfigureAwait(false);
+#endif
+                if (read <= 0)
+                {
+                    return false;
+                }
+
+                total += read;
+            }
+
+            return true;
+        }
+
+        private static async Task WriteFrameAsync(NetworkStream stream, byte[] buffer, CancellationToken cancellationToken)
+        {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+            await stream.WriteAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+#else
+            await stream.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+#endif
+        }
+
+        private async Task WriteHandshakeFrameAsync(NetworkStream stream, byte[] buffer, CancellationToken cancellationToken)
+        {
+            if (!_fragmentHandshakeResponses)
+            {
+                await WriteFrameAsync(stream, buffer, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            for (var i = 0; i < buffer.Length; i++)
+            {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+                await stream.WriteAsync(buffer.AsMemory(i, 1), cancellationToken).ConfigureAwait(false);
+#else
+                await stream.WriteAsync(buffer, i, 1, cancellationToken).ConfigureAwait(false);
+#endif
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                await Task.Delay(2, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task AcceptLoopAsync()
+        {
+            while (!_cancellationTokenSource.IsCancellationRequested)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync().ConfigureAwait(false);
+                }
+                catch (ObjectDisposedException) when (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (SocketException) when (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                _ = HandleClientAsync(client, _cancellationTokenSource.Token);
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+        {
+            using (client)
+            {
+                client.NoDelay = true;
+                var stream = client.GetStream();
+                var buffer = new byte[256];
+
+                if (await ReadTpktAsync(stream, buffer, cancellationToken).ConfigureAwait(false) <= 0)
+                {
+                    return;
+                }
+
+                await WriteHandshakeFrameAsync(stream, ConnectionConfirm, cancellationToken).ConfigureAwait(false);
+
+                if (await ReadTpktAsync(stream, buffer, cancellationToken).ConfigureAwait(false) <= 0)
+                {
+                    return;
+                }
+
+                await WriteHandshakeFrameAsync(stream, SetupConfirm, cancellationToken).ConfigureAwait(false);
+                Interlocked.Increment(ref _handshakeCount);
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    if (await ReadTpktAsync(stream, buffer, cancellationToken).ConfigureAwait(false) <= 0)
+                    {
+                        return;
+                    }
+
+                    Interlocked.Increment(ref _unsupportedRequestCount);
+                    await WriteFrameAsync(stream, UnsupportedDiagnosticResponse, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/src/S7PlcRx/Core/S7SocketRx.cs
+++ b/src/S7PlcRx/Core/S7SocketRx.cs
@@ -37,8 +37,6 @@ internal class S7SocketRx : IDisposable
     private const int PortProbeTimeoutMs = 750;
     private const int AvailabilityFailureThreshold = 3;
     private const int ConnectionFailureThreshold = 3;
-    private static readonly TimeSpan PlcReadyProbeInterval = TimeSpan.FromMilliseconds(250);
-    private static readonly TimeSpan PlcReadyTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan RecentOperationAvailabilityWindow = TimeSpan.FromSeconds(3);
 
     // Enhanced observables for better monitoring
@@ -484,7 +482,6 @@ internal class S7SocketRx : IDisposable
                         lengthOfDataRead = Word.FromByteArray(data, 37);
                         Array.Copy(data, 41, resultData, offset, szlDataLength);
                         offset += szlDataLength;
-                        lengthOfDataRead += lengthOfDataRead;
                         first = false;
                     }
                     else if (Word.FromByteArray(data, 27) == 0 && data[29] == 255)
@@ -494,7 +491,7 @@ internal class S7SocketRx : IDisposable
                         seqIn = data[24];
                         Array.Copy(data, 37, resultData, offset, szlDataLength);
                         offset += szlDataLength;
-                        lengthOfDataRead += lengthOfDataRead;
+                        lengthOfDataRead += (ushort)szlDataLength;
                     }
                     else
                     {
@@ -630,215 +627,6 @@ internal class S7SocketRx : IDisposable
         }
     }
 
-    private async Task<bool> WaitForPlcReadyAsync(Socket socket)
-    {
-        var deadline = DateTime.UtcNow + PlcReadyTimeout;
-        var consecutiveSuccessfulProbes = 0;
-
-        while (!_disposedValue && DateTime.UtcNow < deadline)
-        {
-            if (!CheckConnectionStatusOptimized(socket))
-            {
-                return false;
-            }
-
-            var cpuData = GetSZLData(socket, 28);
-            var orderCode = GetSZLData(socket, 17);
-            if (cpuData.data.Length >= 204 && orderCode.data.Length >= 25)
-            {
-                consecutiveSuccessfulProbes++;
-                if (consecutiveSuccessfulProbes >= 2)
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                consecutiveSuccessfulProbes = 0;
-            }
-
-            await Task.Delay(PlcReadyProbeInterval).ConfigureAwait(false);
-        }
-
-        return false;
-    }
-
-    private (byte[] data, ushort size) GetSZLData(Socket socket, ushort szlArea, ushort index = 0)
-    {
-        byte[] s7_SZL1 = [3, 0, 0, 33, 2, 240, 128, 50, 7, 0, 0, 5, 0, 0, 8, 0, 8, 0, 1, 18, 4, 17, 68, 1, 0, 255, 9, 0, 4, 0, 0, 0, 0];
-        byte[] s7_SZL2 = [3, 0, 0, 33, 2, 240, 128, 50, 7, 0, 0, 6, 0, 0, 12, 0, 4, 0, 1, 18, 8, 18, 68, 1, 1, 0, 0, 0, 0, 10, 0, 0, 0];
-
-        const int bufferSize = 1024;
-        var data = _bufferPool.Rent(bufferSize);
-        var resultData = _bufferPool.Rent(bufferSize);
-
-        try
-        {
-            int length;
-            var done = false;
-            var first = true;
-            byte seqIn = 0;
-            ushort seqOut = 0;
-            var lastError = 0;
-            var offset = 0;
-            ushort lengthOfDataRead = 0;
-            int szlDataLength;
-
-            do
-            {
-                if (first)
-                {
-                    Word.ToByteArray(++seqOut, s7_SZL1, 11);
-                    Word.ToByteArray(szlArea, s7_SZL1, 29);
-                    Word.ToByteArray(index, s7_SZL1, 31);
-                    if (SendOnSocket(socket, s7_SZL1, s7_SZL1.Length) != s7_SZL1.Length)
-                    {
-                        return (Array.Empty<byte>(), 0);
-                    }
-                }
-                else
-                {
-                    Word.ToByteArray(++seqOut, s7_SZL2, 11);
-                    s7_SZL2[24] = seqIn;
-                    if (SendOnSocket(socket, s7_SZL2, s7_SZL2.Length) != s7_SZL2.Length)
-                    {
-                        return (Array.Empty<byte>(), 0);
-                    }
-                }
-
-                length = ReceiveIsoData(socket, ref data);
-
-                if (lastError == 0 && length > 32)
-                {
-                    if (first && Word.FromByteArray(data, 27) == 0 && data[29] == 255)
-                    {
-                        szlDataLength = Word.FromByteArray(data, 31) - 8;
-                        done = data[26] == 0;
-                        seqIn = data[24];
-                        lengthOfDataRead = Word.FromByteArray(data, 37);
-                        Array.Copy(data, 41, resultData, offset, szlDataLength);
-                        offset += szlDataLength;
-                        first = false;
-                    }
-                    else if (Word.FromByteArray(data, 27) == 0 && data[29] == 255)
-                    {
-                        szlDataLength = Word.FromByteArray(data, 31);
-                        done = data[26] == 0;
-                        seqIn = data[24];
-                        Array.Copy(data, 37, resultData, offset, szlDataLength);
-                        offset += szlDataLength;
-                    }
-                    else
-                    {
-                        lastError = (int)ErrorCode.WrongVarFormat;
-                    }
-                }
-                else
-                {
-                    lastError = (int)ErrorCode.WrongNumberReceivedBytes;
-                }
-            }
-            while (!done && lastError == 0);
-
-            if (lastError == 0)
-            {
-                var result = new byte[offset];
-                Array.Copy(resultData, result, offset);
-                return (result, lengthOfDataRead);
-            }
-
-            return (Array.Empty<byte>(), 0);
-        }
-        finally
-        {
-            _bufferPool.Return(data);
-            _bufferPool.Return(resultData);
-        }
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Keep instance methods to satisfy StyleCop member ordering without large refactor in a hot codepath.")]
-    private int SendOnSocket(Socket socket, byte[] buffer, int size)
-    {
-        var total = 0;
-        while (total < size)
-        {
-            var sent = socket.Send(buffer, total, size - total, SocketFlags.None);
-            if (sent <= 0)
-            {
-                return total;
-            }
-
-            total += sent;
-        }
-
-        return total;
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Keep instance methods to satisfy StyleCop member ordering without large refactor in a hot codepath.")]
-    private int ReceiveExact(Socket socket, byte[] buffer, int size, int offset = 0)
-    {
-        var total = 0;
-        while (total < size)
-        {
-            var read = socket.Receive(buffer, offset + total, size - total, SocketFlags.None);
-            if (read <= 0)
-            {
-                return total > 0 ? total : read;
-            }
-
-            total += read;
-        }
-
-        return total;
-    }
-
-    private int ReceiveIsoData(Socket socket, ref byte[] bytes)
-    {
-        var done = false;
-        var size = 0;
-        var lastError = 0;
-
-        while (lastError == 0 && !done)
-        {
-            var headerReceived = ReceiveExact(socket, bytes, 4);
-            if (headerReceived != 4)
-            {
-                lastError = (int)ErrorCode.WrongNumberReceivedBytes;
-                break;
-            }
-
-            size = Word.FromByteArray(bytes, 2);
-
-            if (size == 7)
-            {
-                if (ReceiveExact(socket, bytes, 3, 4) != 3)
-                {
-                    lastError = (int)ErrorCode.WrongNumberReceivedBytes;
-                }
-            }
-            else if (size > DataReadLength + 7 || size < 16)
-            {
-                lastError = (int)ErrorCode.WrongNumberReceivedBytes;
-            }
-            else
-            {
-                done = true;
-            }
-        }
-
-        if (lastError != 0)
-        {
-            return 0;
-        }
-
-        if (ReceiveExact(socket, bytes, 3, 4) != 3)
-        {
-            return 0;
-        }
-
-        return ReceiveExact(socket, bytes, size - 7, 7) == size - 7 ? size : 0;
-    }
-
     private int ReceiveRaw(Tag? tag, byte[] buffer, int size, int offset = 0)
         => ReceiveCore(tag, buffer, size, offset, traceOperation: false);
 
@@ -944,8 +732,7 @@ internal class S7SocketRx : IDisposable
                 }
 
                 // Handshake with current profile
-                if (await PerformOptimizedHandshakeAsync(attemptSocket, profile).ConfigureAwait(false) &&
-                    await WaitForPlcReadyAsync(attemptSocket).ConfigureAwait(false))
+                if (await PerformOptimizedHandshakeAsync(attemptSocket, profile).ConfigureAwait(false))
                 {
                     var oldSocket = _socket;
                     _socket = attemptSocket;
@@ -990,6 +777,7 @@ internal class S7SocketRx : IDisposable
     /// <summary>
     /// Performs an optimized asynchronous handshake using the specified TSAP profile.
     /// </summary>
+    /// <param name="socket">The connected socket used for the handshake.</param>
     /// <param name="profile">The TSAP profile to use for the handshake operation. Cannot be null.</param>
     /// <returns>A task that represents the asynchronous operation. The task result is <see langword="true"/> if the handshake
     /// succeeds; otherwise, <see langword="false"/>.</returns>
@@ -1031,8 +819,7 @@ internal class S7SocketRx : IDisposable
             // Step 2: Receive connection response (TPKT length based)
             var received = await ReceiveTpktExactNetStandardAsync(socket, bReceive, 22).ConfigureAwait(false);
 
-            // minimal TPKT+COTP length sanity
-            if (received < 7)
+            if (received < 22)
             {
                 LogError($"Invalid connection response length {received}");
                 return false;
@@ -1053,7 +840,7 @@ internal class S7SocketRx : IDisposable
 
             // Step 4: Receive communication setup response (TPKT length based)
             received = await ReceiveTpktExactNetStandardAsync(socket, bReceive, 27).ConfigureAwait(false);
-            if (received < 7)
+            if (received < 27)
             {
                 LogError($"Invalid communication setup response length {received}");
                 return false;
@@ -1073,16 +860,19 @@ internal class S7SocketRx : IDisposable
     private async Task<int> ReceiveTpktExactNetStandardAsync(Socket socket, byte[] buffer, int expectedMin)
     {
         // Read TPKT header (4 bytes)
-        var read = await Task.Factory.FromAsync(
-            (cb, s) => socket.BeginReceive(buffer, 0, 4, SocketFlags.None, cb, s),
-            socket.EndReceive,
-            null).ConfigureAwait(false);
+        var read = await ReceiveExactAsync(socket, buffer, 4, 0).ConfigureAwait(false);
         if (read != 4)
         {
             return read;
         }
 
         var length = (buffer[2] << 8) | buffer[3];
+        if (length < 4 || length > buffer.Length)
+        {
+            LogWarning($"Invalid TPKT length {length} for receive buffer {buffer.Length}");
+            return 0;
+        }
+
         if (length < expectedMin && expectedMin > 0)
         {
             // Try to continue anyway, but report
@@ -1090,25 +880,36 @@ internal class S7SocketRx : IDisposable
         }
 
         var remaining = length - 4;
-        var total = 4;
-        while (remaining > 0)
+        if (remaining == 0)
         {
-            var r = await Task.Factory.FromAsync(
-                (cb, s) => socket.BeginReceive(buffer, total, remaining, SocketFlags.None, cb, s),
-                socket.EndReceive,
-                null).ConfigureAwait(false);
-
-            if (r <= 0)
-            {
-                break;
-            }
-
-            total += r;
-            remaining -= r;
+            return read;
         }
 
-        return total;
+        var bodyRead = await ReceiveExactAsync(socket, buffer, remaining, 4).ConfigureAwait(false);
+        return bodyRead <= 0 ? read : read + bodyRead;
+
+        static async Task<int> ReceiveExactAsync(Socket socket, byte[] buffer, int size, int offset)
+        {
+            var total = 0;
+            while (total < size)
+            {
+                var received = await Task.Factory.FromAsync(
+                    (callback, state) => socket.BeginReceive(buffer, offset + total, size - total, SocketFlags.None, callback, state),
+                    socket.EndReceive,
+                    null).ConfigureAwait(false);
+
+                if (received <= 0)
+                {
+                    break;
+                }
+
+                total += received;
+            }
+
+            return total;
+        }
     }
+
 #else
     /// <summary>
     /// Performs an optimized asynchronous handshake sequence with a remote endpoint using the modern socket API.
@@ -1117,6 +918,7 @@ internal class S7SocketRx : IDisposable
     /// connection. If any step in the handshake fails, the method logs an error and returns <see langword="false"/>.
     /// The method does not throw exceptions for handshake failures; instead, it returns <see langword="false"/> to
     /// indicate failure.</remarks>
+    /// <param name="socket">The connected socket used for the handshake.</param>
     /// <param name="bReceive">A buffer used to receive handshake response data from the remote endpoint. Must be large enough to hold the
     /// expected handshake messages.</param>
     /// <param name="profile">The connection profile containing parameters required for the handshake process.</param>
@@ -1137,7 +939,7 @@ internal class S7SocketRx : IDisposable
 
             // Step 2: Receive connection response (TPKT length based)
             var received = await ReceiveTpktExactModernAsync(socket, bReceive, 22).ConfigureAwait(false);
-            if (received < 7)
+            if (received < 22)
             {
                 LogError($"Invalid connection response length {received}");
                 return false;
@@ -1154,7 +956,7 @@ internal class S7SocketRx : IDisposable
 
             // Step 4: Receive communication setup response (TPKT length based)
             received = await ReceiveTpktExactModernAsync(socket, bReceive, 27).ConfigureAwait(false);
-            if (received < 7)
+            if (received < 27)
             {
                 LogError($"Invalid communication setup response length {received}");
                 return false;
@@ -1178,40 +980,58 @@ internal class S7SocketRx : IDisposable
     /// remaining data to complete the packet. If the actual packet length is less than the specified minimum, a warning
     /// is logged but the packet is still read. The method returns as soon as the full packet is received or if the
     /// connection is closed before completion.</remarks>
+    /// <param name="socket">The connected socket to read from.</param>
     /// <param name="buffer">The buffer that receives the TPKT packet data. Must be large enough to hold the entire packet.</param>
     /// <param name="expectedMin">The minimum expected length of the TPKT packet, in bytes. Used for validation; set to 0 to disable the check.</param>
     /// <returns>The total number of bytes read into the buffer, or a value less than 4 if the TPKT header could not be read.</returns>
     private async Task<int> ReceiveTpktExactModernAsync(Socket socket, byte[] buffer, int expectedMin)
     {
         // Read TPKT header (4 bytes)
-        var headerRead = await socket.ReceiveAsync(buffer.AsMemory(0, 4), SocketFlags.None).ConfigureAwait(false);
+        var headerRead = await ReceiveExactAsync(socket, buffer, 4, 0).ConfigureAwait(false);
         if (headerRead != 4)
         {
             return headerRead;
         }
 
         var length = (buffer[2] << 8) | buffer[3];
+        if (length < 4 || length > buffer.Length)
+        {
+            LogWarning($"Invalid TPKT length {length} for receive buffer {buffer.Length}");
+            return 0;
+        }
+
         if (length < expectedMin && expectedMin > 0)
         {
             LogWarning($"TPKT length {length} smaller than expected {expectedMin}");
         }
 
         var remaining = length - 4;
-        var total = 4;
-        while (remaining > 0)
+        if (remaining == 0)
         {
-            var r = await socket.ReceiveAsync(buffer.AsMemory(total, remaining), SocketFlags.None).ConfigureAwait(false);
-            if (r <= 0)
-            {
-                break;
-            }
-
-            total += r;
-            remaining -= r;
+            return headerRead;
         }
 
-        return total;
+        var bodyRead = await ReceiveExactAsync(socket, buffer, remaining, 4).ConfigureAwait(false);
+        return bodyRead <= 0 ? headerRead : headerRead + bodyRead;
+
+        static async Task<int> ReceiveExactAsync(Socket socket, byte[] buffer, int size, int offset)
+        {
+            var total = 0;
+            while (total < size)
+            {
+                var received = await socket.ReceiveAsync(buffer.AsMemory(offset + total, size - total), SocketFlags.None).ConfigureAwait(false);
+                if (received <= 0)
+                {
+                    break;
+                }
+
+                total += received;
+            }
+
+            return total;
+        }
     }
+
 #endif
 
     private async Task ProbeAvailabilityAndNotifyAsync(IObserver<bool> observer)


### PR DESCRIPTION
﻿## Summary

Fixes #200.

Restores S7 connection readiness so a successful COTP/S7 setup handshake marks the PLC as connected without requiring optional SZL diagnostic reads first. This prevents S7-1500 sessions from staying in `IsConnectedValue == false` when the PLC accepts the session but delays or denies diagnostic SZL access.

## Root Cause

Version 2.3.28 introduced a PLC readiness gate after setup that required SZL reads before `_initComplete` could become true. On the connected S7-1500, the TCP/S7 session can be valid while those diagnostics are not yet available, which blocks connection state and watchdog writes.

## Changes

- Removed SZL readiness as a hard connection gate after S7 setup.
- Hardened TPKT handshake reads so fragmented TCP frames are read exactly.
- Rejected invalid or oversized TPKT lengths before reading into the receive buffer.
- Enforced expected minimum lengths for handshake responses.
- Fixed SZL diagnostic size accounting for continuation frames.
- Added regression tests using TUnit assertions for handshake-only readiness, fragmented handshakes, MockS7Plc watchdog writes, and explicit live S7-1500 connection/CPU-info checks.

## Validation

- `dotnet build src\S7PlcRx\S7PlcRx.csproj --framework net8.0 --no-restore`
- `dotnet test src\S7PlcRx.Tests\S7PlcRx.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~S7PlcRxConnectionRegressionTests&Category!=LivePLC"`
- `dotnet test src\S7PlcRx.Tests\S7PlcRx.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~IsConnected_ToLiveS71500_ShouldBecomeTrue|FullyQualifiedName~GetCpuInfo_ToLiveS71500_ShouldCompleteAndReturnIdentityFields"`
- `dotnet test src\S7PlcRx.Tests\S7PlcRx.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~ConnectionReconnection_AfterCableUnplug_ShouldReconnect|FullyQualifiedName~ConnectionReconnection_AfterPLCStopRun_ShouldReconnect"`
- `dotnet test src\S7PlcRx.Tests\S7PlcRx.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~S7PlcRxAsyncExtensionsTests|FullyQualifiedName~S7PlcRxConnectionRegressionTests&Category!=LivePLC"`
- `Test-NetConnection -ComputerName 172.16.13.1 -Port 102`

## PLC Notes

No PLC program changes are required for the live connection and CPU diagnostic tests included here. Live watchdog/read-write testing still requires a writable non-optimized DB word and PUT/GET access, so those checks remain covered with MockS7Plc unless a suitable PLC DB is configured.
